### PR TITLE
Support AWS' canonical import path

### DIFF
--- a/contrib.go.opencensus.io/vanity.yaml
+++ b/contrib.go.opencensus.io/vanity.yaml
@@ -3,3 +3,5 @@ host: contrib.go.opencensus.io
 paths:
   /exporter/stackdriver:
     repo: https://github.com/census-ecosystem/opencensus-go-exporter-stackdriver
+  /exporter/aws:
+    repo: https://github.com/census-ecosystem/opencensus-go-exporter-aws


### PR DESCRIPTION
User should be able to go get via
contrib.go.opencensus.io/exporter/aws.