### PR TITLE
Add ocsql project to contrib.go.opencensus.io

### DIFF
--- a/contrib.go.opencensus.io/vanity.yaml
+++ b/contrib.go.opencensus.io/vanity.yaml
@@ -11,4 +11,6 @@ paths:
     repo: https://github.com/census-ecosystem/opencensus-go-exporter-ocagent
   /resource:
     repo: https://github.com/census-ecosystem/opencensus-go-resource
+  /integrations/ocsql:
+    repo: https://github.com/opencensus-integrations/ocsql
 


### PR DESCRIPTION
Add ocsql project to contrib.go.opencensus.io vanity urls to highlight the community supported status of this project.

See https://github.com/opencensus-integrations/ocsql/issues/16