### PR TITLE
Remove vanity url config for go.opentelemetry.io.

### DIFF
--- a/go.opentelemetry.io/deploy.sh
+++ b/go.opentelemetry.io/deploy.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-git clone https://github.com/GoogleCloudPlatform/govanityurls.git \
-    && cp vanity.yaml govanityurls \
-    && cd govanityurls \
-    && gcloud app deploy --project=opentelemetry-go

--- a/go.opentelemetry.io/vanity.yaml
+++ b/go.opentelemetry.io/vanity.yaml
@@ -1,7 +1,0 @@
-host: go.opentelemetry.io
-
-paths:
-  /otel:
-    repo: https://github.com/open-telemetry/opentelemetry-go
-  /contrib:
-    repo: https://github.com/open-telemetry/opentelemetry-go-contrib


### PR DESCRIPTION
- This is covered under http://github.com/open-telemetry/opentelemetry-go-vanityurls